### PR TITLE
Add missing Hornmoots; reformat calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,31 +91,36 @@
                     <div class="col-lg-12">
                         <h1>Calendar of Harptos</h1>
 						<p>Significant holidays and seasons in the world of Faerûn.</p>
-						<a name="Hammer"></a> 
-						<h3>Hammer (Deepwinter)</h3>
-
+						
 						<table class="table table-bordered">
-						<thead>
-						<th><b>First-day</b></th>
+                        <tr>
+                        <th colspan="10">
+                        <a name="Hammer"></a> 
+						<h3>Hammer (Deepwinter)</h3>
+                        <p>Sign of the Badger</p></th>
+                        </tr>
+                        
+						<tr>
+						<th width="10%"><b>First-day</b></th>
 
-						<th><b>Second-day</b></th>
+						<th width="10%"><b>Second-day</b></th>
 
-						<th><b>Third-day</b></th>
+						<th width="10%"><b>Third-day</b></th>
 
-						<th><b>Fourth-day</b></th>
+						<th width="10%"><b>Fourth-day</b></th>
 
-						<th><b>Fifth-day</b></th>
+						<th width="10%"><b>Fifth-day</b></th>
 
-						<th><b>Sixth-day</b></th>
+						<th width="10%"><b>Sixth-day</b></th>
 
-						<th><b>Seventh-day</b></th>
+						<th width="10%"><b>Seventh-day</b></th>
 
-						<th><b>Eighth-day</b></th>
+						<th width="10%"><b>Eighth-day</b></th>
 
-						<th><b>Ninth-day</b></th>
+						<th width="10%"><b>Ninth-day</b></th>
 
-						<th><b>Tenth-day</b></th>
-						</thead>
+						<th width="10%"><b>Tenth-day</b></th>
+						</tr>
 
 						<tr class="calendar-cells">
 						<td>1</td>
@@ -180,13 +185,25 @@
 
 						<td>29</td>
 
-						<td>30<br><b>Midwinter</b></td>
+						<td>30<br></td>
 						</tr>
-						</table>
-						<a name="Alturiak"></a> 
-						<h3>Alturiak (The Claw of Winter)</h3>
 
-						<table class="table table-bordered">
+                        <tr>
+                        <th>
+                        <b>Midwinter<sup>&dagger;</sup></b><br>
+                        <b>Sign of the Boar</b>
+                        </th>
+                        <th colspan="9">&nbsp;</th>
+                        </tr>
+
+						<tr>
+                        <th colspan="10">
+                        <a name="Alturiak"></a> 
+						<h3>Alturiak (The Claw of Winter)</h3>
+                        <p>Sign of the Spider</p>
+                        </th>
+                        </tr>
+
 						<tr>
 						<td><b>First-day</b></td>
 
@@ -274,12 +291,15 @@
 
 						<td>30</td>
 						</tr>
-						</table>
 
-						<a name="Ches"></a> 						
+						<tr>
+                        <th colspan="10">
+                        <a name="Ches"></a> 						
 						<h3>Ches (The Claw of Sunsets)</h3>
+                        <p>Sign of the Serpent</p>
+                        </th>
+                        </tr>
 
-						<table class="table table-bordered">
 						<tr>
 						<td><b>First-day</b></td>
 
@@ -368,12 +388,15 @@
 
 						<td>30<br><b>Fleetswake<br>(Waterdeep)</b></td>
 						</tr>
-						</table>
 
-						<a name="Tarsakh"></a> 						
+						<tr>
+                        <th colspan="10">
+                        <a name="Tarsakh"></a> 						
 						<h3>Tarsakh (The Claw of Storms)</h3>
+                        <p>Sign of the Panther</p>
+                        </th>
+                        </tr>
 
-						<table class="table table-bordered">
 						<tr>
 						<td><b>First-day</b></td>
 
@@ -459,14 +482,25 @@
 
 						<td>29</td>
 
-						<td>30<br><b>Greengrass</b></td>
+						<td>30</td>
 						</tr>
-						</table>
-						
-						<a name="Mirtul"></a> 						
-						<h3>Mirtul (The Melting)</h3>
+                        
+                        <tr>
+                        <th>
+                        <b>Greengrass<sup>&dagger;</sup></b><br>
+                        <b>Sign of the Elk</b>
+                        </th>
+                        <th colspan="9">&nbsp;</th>
+                        </tr>
 
-						<table class="table table-bordered">
+						<tr>
+                        <th colspan="10">
+                        <a name="Mirtul"></a> 						
+						<h3>Mirtul (The Melting)</h3>
+                        <p>Sign of the Fox</p>
+                        </th>
+                        </tr>
+
 						<tr class="calendar-cells">
 						<td><b>First-day</b></td>
 
@@ -554,12 +588,15 @@
 
 						<td>30</td>
 						</tr>
-						</table>
 
-						<a name="Kythorn"></a> 						
+						<tr>
+                        <th colspan="10">
+                        <a name="Kythorn"></a> 						
 						<h3>Kythorn (The Time of Flowers)</h3>
+                        <p>Sign of the Moth</p>
+                        </th>
+                        </tr>
 
-						<table class="table table-bordered">
 						<tr>
 						<td><b>First-day</b></td>
 
@@ -648,12 +685,15 @@
 
 						<td>30</td>
 						</tr>
-						</table>
 
-						<a name="Flamerule"></a> 						
+						<tr>
+                        <th colspan="10">
+                        <a name="Flamerule"></a> 						
 						<h3>Flamerule (Summertide)</h3>
+                        <p>Sign of the Salamander</p>
+                        </th>
+                        </tr>
 
-						<table class="table table-bordered">
 						<tr>
 						<td><b>First-day</b></td>
 
@@ -705,7 +745,7 @@
 
 						<td>13</td>
 
-						<td>14</td>
+						<td>14<br><b>Lesser Hornmoot<br>(The Vast)</b></td>
 
 						<td>15</td>
 
@@ -739,17 +779,33 @@
 
 						<td>29</td>
 
-						<td>30<br><b>Midsummer</b></td>
+						<td>30<br><b></b></td>
 						</tr>
-						<tr class="calendar-cells">
-						<td>31 <br><b>Shieldmeet*<br></b></td>
-						</tr >
-						</table>
-<p>*Leap Day, once every fourth year. For example, 4 DR had a Shieldmeet</p>
+
+						<tr>
+                        <th>
+                        <b>Midsummer<sup>&dagger;</sup></b><br>
+                        <b>Sign of the Albatross</b>
+                        </th>
+                        <th colspan="9">&nbsp;</th>
+                        </tr>
+                        
+                        <tr>
+                        <th>
+                        <b>Shieldmeet*</b><br>
+                        <b>Sign of the Owl</b>
+                        </th>
+                        <th colspan="9">&nbsp;</th>
+                        </tr>
+                        
+                        <tr>
+                        <th colspan="10">
 						<a name="Eleasis"></a> 						
 						<h3>Eleasis (Highsun)</h3>
+                        <p>Sign of the Owl</p>
+                        </th>
+                        </tr>
 
-						<table class="table table-bordered">
 						<tr>
 						<td><b>First-day</b></td>
 
@@ -801,7 +857,7 @@
 
 						<td>13</td>
 
-						<td>14</td>
+						<td>14<br><b>Lesser Hornmoot<br>(The Vast)</b></td>
 
 						<td>15</td>
 
@@ -837,12 +893,15 @@
 
 						<td>30</td>
 						</tr>
-						</table>
 
-						<a name="Eleint"></a> 						
+						<tr>
+                        <th colspan="10">
+                        <a name="Eleint"></a> 						
 						<h3>Eleint (The Fading)</h3>
+                        <p>Sign of the Eagle</p>
+                        </th>
+                        </tr>
 
-						<table class="table table-bordered">
 						<tr>
 						<td><b>First-day</b></td>
 
@@ -894,7 +953,7 @@
 
 						<td>13</td>
 
-						<td>14</td>
+						<td>14<br><b>Final Hornmoot<br>(The Vast)</b></td>
 
 						<td>15</td>
 
@@ -929,14 +988,25 @@
 
 						<td>29</td>
 
-						<td>30<br><b>Highharvestide</b></td>
+						<td>30</td>
 						</tr>
-						</table>
 
-						<a name="Marpenoth"></a> 						
+						<tr>
+                        <th>
+                        <b>Highharvestide<sup>&dagger;</sup></b><br>
+                        <b>Sign of the Raven</b>
+                        </th>
+                        <th colspan="9">&nbsp;</th>
+                        </tr>
+
+						<tr>
+                        <th colspan="10">
+                        <a name="Marpenoth"></a> 						
 						<h3>Marpenoth (Leaffall)</h3>
+                        <p>Sign of the Praying Mantis</p>
+                        </th>
+                        </tr>
 
-						<table class="table table-bordered">
 						<tr>
 						<td><b>First-day</b></td>
 
@@ -1024,12 +1094,15 @@
 
 						<td>30</td>
 						</tr>
-						</table>
 
-						<a name="Uktar"></a> 						
+						<tr>
+                        <th colspan="10">
+                        <a name="Uktar"></a> 						
 						<h3>Uktar (The Rotting)</h3>
+                        <p>Sign of the Falcon</p>
+                        </th>
+                        </tr>
 
-						<table class="table table-bordered">
 						<tr>
 						<td><b>First-day</b></td>
 
@@ -1115,14 +1188,25 @@
 
 						<td>29</td>
 
-						<td>30<br><b>Feast of the Moon</td>
+						<td>30</td>
 						</tr>
-						</table>
 
-						<a name="Nightal"></a> 					
+						<tr>
+                        <th>
+                        <b>Feast of the Moon<sup>&dagger;</sup></b><br>
+                        <b>Sign of the Wolf</b>
+                        </th>
+                        <th colspan="9">&nbsp;</th>
+                        </tr>
+
+						<tr>
+                        <th colspan="10">
+                        <a name="Nightal"></a> 					
 						<h3>Nightal (The Drawing Down)</h3>
+                        <p>Sign of the Bear</p>
+                        </th>
+                        </tr>
 
-						<table class="table table-bordered">
 						<tr>
 						<td><b>First-day</b></td>
 
@@ -1212,6 +1296,14 @@
 						<td>30</td>
 						</tr>
 						</table>
+                        
+<h4>Notes</h4>
+<p><b>*</b> Leap Day, once every fourth year. For example, 4 DR had a Shieldmeet.</p>
+<p><b><sup>&dagger;</sup></b> Extra day added between months.</p>
+
+<p>This calendar is the most-used in Faerûn, and was created by the wizard Harptos of Kaalinth. It is split into 12 months, each lasting three ten-days. There are an additional five days that fall between months, bringing the total number of days in most years to 365. Every fourth year has an additional day added, known as Shieldmeet, the equivalent of a leap year day.</p>
+                        
+<p>The wizard Harptos also designed a zodiac, based on the most prominent constellation in night sky for each month. Rather than having the five extra days "borrow" a constel­lation from a neighboring month, they have their own signs related to the most brilliant star in the night sky in those days. Shieldmeet is the exception to this, as it uses the sign of the Owl, taken from the following month of Eleasias.</p>
 
 
 					</div>	


### PR DESCRIPTION
Add Lesser Hornmoots and Final Hornmoot to calendar.
Reformat calendar into a single HTML table, to standardize column widths.
Move extra days and leap day to their own rows; add footnotes.
Add zodiac signs to calendar.
Add information about the calendar's creation.